### PR TITLE
Improve tooltip accessibility

### DIFF
--- a/overlapping-plugins.json
+++ b/overlapping-plugins.json
@@ -1,0 +1,22 @@
+{
+  "transform-async-to-generator": [
+    "bugfix/transform-async-arrows-in-class"
+  ],
+  "transform-parameters": [
+    "bugfix/transform-edge-default-parameters",
+    "bugfix/transform-safari-id-destructuring-collision-in-function-expression"
+  ],
+  "transform-function-name": [
+    "bugfix/transform-edge-function-name"
+  ],
+  "transform-block-scoping": [
+    "bugfix/transform-safari-block-shadowing",
+    "bugfix/transform-safari-for-shadowing"
+  ],
+  "transform-template-literals": [
+    "bugfix/transform-tagged-template-caching"
+  ],
+  "proposal-optional-chaining": [
+    "bugfix/transform-v8-spread-parameters-in-optional-chaining"
+  ]
+}


### PR DESCRIPTION
Improve keyboard and screen-reader access to tooltips by replacing title attributes with aria-describedby and adding role tooltip on tooltip elements. Make tooltip triggers focusable and show tooltip on focus; update CSS to preserve layout and avoid visual regressions.